### PR TITLE
Updates locate_config_file scope to reflect its change to a class method in commit 2a214bc

### DIFF
--- a/lib/chef/knife/block.rb
+++ b/lib/chef/knife/block.rb
@@ -15,7 +15,7 @@ class Chef
       # locate_config_file is only compatible with Chef 11
       _chef11 = ::Chef::Version.new('11.0.0')
       if GreenAndSecure.current_chef_version >= _chef11
-        locate_config_file if not config[:config_file]
+        config[:config_file] ||= ::Chef::Knife.locate_config_file
       else
         GreenAndSecure.locate_config_file config
       end


### PR DESCRIPTION
The locate_config_file was changed to  a class method on  2013-10-09:
https://github.com/opscode/chef/commit/2a214bcff7174b61129a7a8a642b8df5b5f4afee#diff-1220e994288a7f7d9ae83196ce7fad9eL317

This fixes the scope and uses an abbreviated assignment for  config[:config_file]

Note: I did not bump the gem tag.

Thanks!
