### PR TITLE
Fix locate_config_file for Chef < 11.8

### DIFF
--- a/lib/chef/knife/block.rb
+++ b/lib/chef/knife/block.rb
@@ -15,7 +15,7 @@ class Chef
       if GreenAndSecure.current_chef_version >= ::Chef::Version.new('11.8.0')
         config[:config_file] ||= ::Chef::Knife.locate_config_file
       elsif GreenAndSecure.current_chef_version >= ::Chef::Version.new('11.0.0')
-        config[:config_file] ||= locate_config_file
+        locate_config_file
       else
         GreenAndSecure.locate_config_file config
       end


### PR DESCRIPTION
The change to a class method wasn't added until
Chef 11.8.x. This change will allow Chef 11
through 11.6 to work.

Fixes #13, #14
