### PR TITLE
Windows support hacks

### DIFF
--- a/lib/chef/knife/block.rb
+++ b/lib/chef/knife/block.rb
@@ -6,6 +6,8 @@
 # Copyright (c) Matthew Macdonald-Wallace / Green and Secure IT Limited 2012
 #
 
+require 'windows_redefine_file_symlink'
+
 # Monkey patch ::Chef::Knife to give us back the config file, cause there's
 # no public method to actually use the lookup logic
 class Chef
@@ -20,7 +22,7 @@ class Chef
         GreenAndSecure.locate_config_file config
       end
 
-      File.dirname(config[:config_file])
+      config[:config_file]
     end
   end
 end
@@ -34,7 +36,12 @@ module GreenAndSecure
   end
 
   def chef_config_base
-    @@knife.get_config_file
+    config_file = @@knife.get_config_file
+    if config_file
+      File.dirname(config_file)
+    else
+      Dir.home + "/.chef"
+    end
   end
 
   # Copied from chef/knife.rb
@@ -222,7 +229,7 @@ module GreenAndSecure
       knife_config.config[:client_key] = "#{GreenAndSecure::chef_config_base}/#{@client_name}-#{@config_name}.pem"
       knife_config.run
 
-      puts "#{GreenAndSecure::chef_config_base}/knife-#{@config_name}.rb has been sucessfully created"
+      puts "#{GreenAndSecure::chef_config_base}/knife-#{@config_name}.rb has been successfully created"
       GreenAndSecure::BlockList.new.run
       use = GreenAndSecure::BlockUse.new
       use.name_args = [@config_name]

--- a/lib/windows_redefine_file_symlink.rb
+++ b/lib/windows_redefine_file_symlink.rb
@@ -1,0 +1,56 @@
+# File class override of symlink behaviors
+# Created by Gabe
+
+require 'open3'
+
+class << File
+  alias_method :old_symlink, :symlink
+  alias_method :old_symlink?, :symlink?
+  alias_method :old_readlink, :readlink
+
+  def symlink(old_name, new_name)
+    #if on windows, call mklink, else self.symlink
+    if RUBY_PLATFORM =~ /mswin32|cygwin|mingw|bccwin/
+      #windows mklink syntax is reverse of unix ln -s
+      #windows mklink is built into cmd.exe
+      #windows cmd.exe will choke on forward slash before filename.
+      old_name.gsub!(/\//, '\\') #replace forward slash with a backslash. Bug case: escaped forward slashes.
+      #vulnerable to command injection, but okay because this is a hack to make a cli tool work.
+      stdin, stdout, stderr, wait_thr = Open3.popen3("cmd.exe /c mklink \"#{new_name}\" \"#{old_name}\"")
+      #puts stdout.gets
+      puts stderr.gets
+      wait_thr.value.exitstatus
+    else
+      self.old_symlink(old_name, new_name)
+    end
+  end
+
+  def symlink?(file_name)
+    if RUBY_PLATFORM =~ /mswin32|cygwin|mingw|bccwin/
+      #vulnerable to command injection because calling with cmd.exe with /c?
+      stdin, stdout, stderr, wait_thr = Open3.popen3("cmd.exe /c dir \"#{file_name}\" | find \"SYMLINK\"")
+      wait_thr.value.exitstatus
+    else
+      self.old_symlink?(file_name)
+    end
+  end
+
+  def readlink(file_name)
+    if RUBY_PLATFORM =~ /mswin32|cygwin|mingw|bccwin/
+      #vulnerable to command injection because calling with cmd.exe with /c?
+      file_name = file_name.sub(/(.*)\//,'\1\\') #replace final forward slash with backslash to workaround cmd.exe
+      stdin, stdout, stderr, wait_thr = Open3.popen3("cmd.exe /c dir \"#{file_name}\" | find \"SYMLINK\"")
+      wait_thr.value.exitstatus
+      line = stdout.gets
+      if line
+        target = line.match('.+\[(.+)\]')[1]
+      else
+        target = nil
+      end
+      target
+    else
+      self.old_readlink?(file_name)
+    end
+  end
+end
+


### PR DESCRIPTION
I really wanted to use knife-block on windows. So i came up with some kinda ugly hacks to make it work by redefining some File class method to shell out to the mklink cmd.exe function. 

I also changed `def get_config_file` to just return any found config file and moved the Dirname logic to the callee to match the function name and similar knife function. I also provided a default config directory for cases when knife.rb does not exist. 

I did not test this on OSX after my changes. please check on OSX before publishing.

Mind bumping the version and publishing a new gem? 
